### PR TITLE
Fix detection of setImmediate

### DIFF
--- a/source/class/core/util/Function.js
+++ b/source/class/core/util/Function.js
@@ -29,6 +29,8 @@
       immediate = function(func) {
         return setTimeout(func, 0);
       };
+    } else {
+      immediate = global[immediate];
     }
   }
 


### PR DESCRIPTION
core.util.Experimental only returns name of function as string,
so setting immediate via Experimental.get has to do a lookup on
the given object to get function itself.
