### PR TITLE
use importScripts in native if available

### DIFF
--- a/source/class/core/io/Script.js
+++ b/source/class/core/io/Script.js
@@ -27,12 +27,15 @@
 	// If native, try to use importScripts; if not available shim importScripts via use of eval and readFileSync.
 	if (jasy.Env.isSet("runtime", "native"))
 	{
-		if (!importScripts) {
+		var importScripts = global.importScripts ? global.importScripts : (function() {
 			var Fs = require("fs");
-			var importScripts = function(uri) {
-				eval("//@ sourceURL=" + uri + "\n" + Fs.readFileSync(uri, "utf-8"));
+			return function() {
+				for (var i=0,ii=arguments.length; i<ii; i++) {
+					var uri = arguments[i];
+					eval("//@ sourceURL=" + uri + "\n" + Fs.readFileSync(uri, "utf-8"));
+				}
 			}
-		}
+		})();
 	}
 
 	/**


### PR DESCRIPTION
The native environment (e.g. nodeJS) can provide a worker compatible importScripts function. If it is available core.io.Script should use this. Otherwise use eval and sync file read as shim.

Background: nodeJS's eval don't support good debug output if something bad happen inside provided code. importScripts can implement a script loader that supports full debug output for nodeJS.
