### PR TITLE
Fix test suites to not exit if no test available.

### DIFF
--- a/source/class/core/testrunner/Controller.js
+++ b/source/class/core/testrunner/Controller.js
@@ -180,7 +180,10 @@ core.Module("core.testrunner.Controller",
       var testStarted = core.Function.bind(this.__testStarted, this);
       var testFinished = core.Function.bind(this.__testFinished, this);
 
-      currentSuite.run(allComplete, testStarted, testFinished, true);
+      var hasTests = currentSuite.run(allComplete, testStarted, testFinished, true);
+      if (!hasTests) {
+        this.__runNextSuite();
+      }
     }
     else if (this.__isRunning)
     {


### PR DESCRIPTION
PhantomJS don't exit when there are no tests inside of a test suite.
