### PR TITLE
In function timeout the context is optional. In debug mode context is checked for type Object.

### DIFF
--- a/source/class/core/Function.js
+++ b/source/class/core/Function.js
@@ -36,7 +36,9 @@
       if (jasy.Env.isSet("debug"))
       {
         core.Assert.isType(callback, "Function");
-        core.Assert.isType(context, "Object");
+        if (context) {
+          core.Assert.isType(context, "Object");
+        }
         core.Assert.isType(delay, "Integer");
       }
 


### PR DESCRIPTION
If no context is given this fails. Now context is only checked if context is given.
